### PR TITLE
fix: clone methods correctly handle teeing body stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.2",
+      "name": "react-native-fetch-api",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "p-defer": "^3.0.0"

--- a/src/Body.js
+++ b/src/Body.js
@@ -6,6 +6,7 @@ class Body {
         this._bodyInit = body;
 
         if (!body) {
+            this._bodyNull = true;
             this._bodyText = "";
             return this;
         }
@@ -179,6 +180,10 @@ class Body {
     }
 
     get body() {
+        if (this._bodyNull) {
+            return null;
+        }
+
         if (this._bodyReadableStream) {
             return this._bodyReadableStream;
         }
@@ -227,6 +232,16 @@ class Body {
                 controller.close();
             },
         });
+    }
+
+    clone() {
+        if (this._bodyReadableStream) {
+            const [stream1, stream2] = this._bodyReadableStream.tee();
+            this._bodyReadableStream = stream1;
+            return new Body(stream2);
+        } else {
+            return new Body(this._bodyInit);
+        }
     }
 }
 

--- a/src/Request.js
+++ b/src/Request.js
@@ -46,7 +46,7 @@ class Request {
         this.signal = request.signal;
         this.headers = new Headers(options.headers ?? request.headers);
 
-        if (!options.body && request._body._bodyInit) {
+        if (options.body === undefined && request._body._bodyInit) {
             this._body = new Body(request._body._bodyInit);
             request._body.bodyUsed = true;
         }
@@ -85,7 +85,14 @@ class Request {
     }
 
     clone() {
-        return new Request(this, { body: this._body._bodyInit });
+        if (this.bodyUsed) {
+            throw new TypeError("Already read");
+        }
+
+        const newRequest = new Request(this, { body: null });
+        newRequest._body = this._body.clone();
+
+        return newRequest;
     }
 
     blob() {

--- a/src/Response.js
+++ b/src/Response.js
@@ -21,12 +21,19 @@ class Response {
     }
 
     clone() {
-        return new Response(this._body._bodyInit, {
+        if (this.bodyUsed) {
+            throw new TypeError("Already read");
+        }
+
+        const newResponse = new Response(null, {
             status: this.status,
             statusText: this.statusText,
             headers: new Headers(this.headers),
             url: this.url,
         });
+        newResponse._body = this._body.clone();
+
+        return newResponse;
     }
 
     blob() {


### PR DESCRIPTION
Encountered error `This stream has already been locked for exclusive reading by another reader` when cloning a response that gets read as a stream. Problem was we did not handle teeing the body stream when cloning happens. The fix is:

1. Response/Request clone method creates a new instance with a null body
2. Source body is cloned
3. Body clone method tees stream, sets its stream to one output, and returns a body with second output
4. Response/Request clone sets body on cloned instance
5. Response/Request clone returns new instance

Also added a few updates to correct the behavior of this library wrt the spec. Namely body class handles explicitly null bodyInit and request/response clone methods check if the body has been used before executing.

Test cases added / modified to verify the new cloning behavior